### PR TITLE
Granger Casuality Classes V.1

### DIFF
--- a/granger_casuality.py
+++ b/granger_casuality.py
@@ -1,0 +1,76 @@
+import pandas as pd
+import numpy as np
+from statsmodels.tsa.stattools import grangercausalitytests
+
+class GrangerCausalityAnalysis:
+    """
+    A class to perform Granger causality analysis between pairs of stock tickers.
+    
+    Attributes:
+        dataframe (pandas.DataFrame): The DataFrame containing stock prices.
+        max_lag (int): The maximum lag to test for Granger causality.
+    """
+    
+    def __init__(self, dataframe, max_lag=5):
+        """
+        Initialize the GrangerCausalityAnalysis object.
+        
+        Args:
+            dataframe (pandas.DataFrame): DataFrame containing stock prices.
+            max_lag (int): Maximum lag to test for Granger causality.
+        """
+        self.dataframe = dataframe
+        self.tickers = dataframe.columns  # Automatically get tickers from DataFrame columns
+        self.max_lag = max_lag
+        self.results = {}  # To store Granger causality results for each pair
+
+    def calculate_granger_causality(self):
+        """
+        Calculate Granger causality for each pair of tickers.
+        
+        Returns:
+            dict: A dictionary containing Granger causality test results for each ticker pair.
+        """
+        for i in range(len(self.tickers)):
+            for j in range(len(self.tickers)):
+                if i != j:  # Don't test ticker against itself
+                    ticker_x = self.tickers[i]
+                    ticker_y = self.tickers[j]
+                    
+                    # Prepare data for Granger causality test
+                    data = self.dataframe[[ticker_x, ticker_y]].dropna()
+                    
+                    # Run Granger causality test
+                    result = grangercausalitytests(data, maxlag=self.max_lag, verbose=False)
+                    
+                    # Extract and store p-values and F-statistics for each lag
+                    p_values = [result[lag][0]['ssr_ftest'][1] for lag in range(1, self.max_lag + 1)]
+                    f_stats = [result[lag][0]['ssr_ftest'][0] for lag in range(1, self.max_lag + 1)]
+                    
+                    # Store results in a dictionary
+                    self.results[(ticker_x, ticker_y)] = {
+                        "p_values": p_values,
+                        "f_statistics": f_stats
+                    }
+
+        return self.results
+
+    def significant_causality_pairs(self, alpha=0.05):
+        """
+        Identify ticker pairs with significant Granger causality.
+        
+        Args:
+            alpha (float): Significance level threshold for p-values (default is 0.05).
+        
+        Returns:
+            list: List of ticker pairs with Granger causality (based on p-value threshold).
+        """
+        significant_pairs = []
+        
+        for (ticker_x, ticker_y), result in self.results.items():
+            # Check if any p-value is below the significance level
+            if any(p < alpha for p in result['p_values']):
+                significant_pairs.append((ticker_x, ticker_y))
+                print(f"{ticker_x} Granger-causes {ticker_y} with p-values {result['p_values']}")
+
+        return significant_pairs

--- a/nonlin_granger_casuality.py
+++ b/nonlin_granger_casuality.py
@@ -1,0 +1,110 @@
+
+"""" https://pypi.org/project/nonlincausality/#description 
+     https://github.com/mrosol/Nonlincausality/blob/master/README.md
+"""
+import pandas as pd
+from nonlincausality import nonlincausalityNN as nlc_nn
+
+class NonlinearNNGrangerCausalityAnalysis:
+    """
+    This class performs nonlinear Granger causality analysis between pairs of stock tickers 
+    using the nonlincausalityNN method from the nonlincausality library. It applies neural 
+    networks to forecast and test for causality in time series data, allowing for the capture 
+    of nonlinear dependencies.
+    """
+    
+    def __init__(self, dataframe, max_lag=5, nn_config=['d','dr','d','dr'], nn_neurons=[100, 0.05, 100, 0.05]): #MLP Version
+        """
+        Initializes the NonlinearNNGrangerCausalityAnalysis object with stock data and configuration.
+
+        Args:
+            dataframe (pd.DataFrame): A DataFrame containing time series data of stock prices.
+            max_lag (int): The maximum number of lags to consider when testing for causality.
+            nn_config (list): List defining the configuration of the neural network layers.
+                - 'd' stands for dense layer, 'dr' stands for dropout regularization.
+            nn_neurons (list): List specifying the number of neurons in each layer and dropout rate.
+                - The format: [neurons, dropout_rate, neurons, dropout_rate, ...]
+        """
+        # Store the dataframe with stock data
+        self.dataframe = dataframe
+        # Extract the column names (tickers) from the DataFrame
+        self.tickers = dataframe.columns
+        # Store the maximum lag for causality tests
+        self.max_lag = max_lag
+        # Store the neural network configuration
+        self.nn_config = nn_config
+        # Store the number of neurons and dropout rates for the neural network layers
+        self.nn_neurons = nn_neurons
+        # Initialize an empty dictionary to store causality results
+        self.results = {}
+
+    def calculate_nonlinear_nn_causality(self, epochs=[50, 50], learning_rate=[0.0001, 0.00001], batch_size=32):
+        """
+        Calculate nonlinear Granger causality for each pair of tickers using a neural network-based 
+        forecasting method.
+
+        Args:
+            epochs (list): List specifying the number of epochs for training the neural network 
+                           for each phase of the model.
+            learning_rate (list): List of learning rates for each training phase.
+            batch_size (int): The size of the batch used during training.
+
+        Returns:
+            dict: A dictionary where keys are ticker pairs (ticker_x, ticker_y), and the values are 
+                  another dictionary containing causality scores and p-values.
+        """
+        # Iterate over all pairs of tickers
+        for i, ticker_x in enumerate(self.tickers):
+            for j, ticker_y in enumerate(self.tickers):
+                if i != j:  # Skip if the tickers are the same
+                    # Prepare data for the analysis: Extract the time series of stock prices for both tickers
+                    data_x = self.dataframe[ticker_x].dropna().values.reshape(-1, 1)  # Reshape for model input
+                    data_y = self.dataframe[ticker_y].dropna().values.reshape(-1, 1)
+                    
+                    # Split data into training and validation sets (70% training, 30% validation)
+                    train_size = int(0.7 * len(data_x))  # 70% for training
+                    data_train, data_val = data_x[:train_size], data_x[train_size:]
+                    
+                    # Perform the nonlinear Granger causality test using the nonlincausalityNN method
+                    result = nlc_nn(
+                        x=data_train,  # Training data for ticker_x
+                        maxlag=self.max_lag,  # Maximum lag for Granger causality
+                        NN_config=self.nn_config,  # Neural network configuration
+                        NN_neurons=self.nn_neurons,  # Number of neurons and dropout rates
+                        x_test=data_y,  # Testing data for ticker_y
+                        run=1,  # Number of runs for the analysis
+                        epochs_num=epochs,  # Number of epochs per training phase
+                        learning_rate=learning_rate,  # Learning rate for each phase
+                        batch_size_num=batch_size,  # Batch size during training
+                        x_val=data_val,  # Validation data
+                        verbose=True,  # Set to True to print verbose output during training
+                        plot=False  # Set to False to disable plotting
+                    )
+                    
+                    # Store the results (causality score and p-value) in the dictionary
+                    self.results[(ticker_x, ticker_y)] = {
+                        "causality_score": result['causality_score'],  # Causality score from the model
+                        "p_value": result['p_value']  # p-value from the test indicating statistical significance
+                    }
+
+        return self.results
+
+    def significant_causality_pairs(self, alpha=0.05):
+        """
+        Identifies ticker pairs with significant nonlinear Granger causality based on p-values.
+
+        Args:
+            alpha (float): The significance threshold for p-values, typically 0.05.
+
+        Returns:
+            list: A list of pairs (ticker_x, ticker_y) that exhibit significant nonlinear causality.
+        """
+        significant_pairs = []
+        
+        # Iterate through the results to check which pairs are significant
+        for (ticker_x, ticker_y), result in self.results.items():
+            if result['p_value'] < alpha:  # Check if the p-value is less than the significance threshold
+                significant_pairs.append((ticker_x, ticker_y))
+                print(f"{ticker_x} nonlinearly causes {ticker_y} with p-value {result['p_value']}")
+        
+        return significant_pairs


### PR DESCRIPTION
1st attempt of implementation for 2 types of Granger Casuality: linear and non-linear(with MLP architecture for the NN).
To test the classes:

**LINEAR Granger Casuality:**


```
# Initialize the Granger causality analysis class
granger_analysis = GrangerCausalityAnalysis(dataframe=df_nasdaq, max_lag=5)
# Calculate Granger causality
results = granger_analysis.calculate_granger_causality()
# Find and print significant causality pairs
significant_pairs = granger_analysis.significant_causality_pairs(alpha=0.05)
print("Significant Granger causality pairs:", significant_pairs)
```

**NON-LINEAR Granger Casuality:**

```
causality_analyzer = NonlinearNNGrangerCausalityAnalysis(
        dataframe=df_nasdaq,
        max_lag=5,
        nn_config=['d', 'dr', 'd', 'dr'],
        nn_neurons=[100, 0.05, 100, 0.05]
    ) 
 # Run the causality analysis
results = causality_analyzer.calculate_nonlinear_nn_causality(
        epochs=[50, 50],
        learning_rate=[0.0001, 0.00001],
        batch_size=32
    )
# Identify significant causality pairs
significant_pairs = causality_analyzer.significant_causality_pairs(alpha=0.05)
    
# Display results
print("Causality Analysis Results:", results)
print("Significant Causality Pairs:", significant_pairs)
```